### PR TITLE
장바구니 기능 수정

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -40,7 +40,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (!token) {
           setIsLoggedIn(false);
           setIsLoading(false);
-          router.push("/login");
           return;
         }
 

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -58,7 +58,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             router.push("/login");
             return;
           }
-          throw new Error("서버 오류 발생");
+          throw new Error("서버 오류 발생: 로그인 되지 않았습니다.");
         }
 
         const data = await res.json();

--- a/feature/cart/CartItem.tsx
+++ b/feature/cart/CartItem.tsx
@@ -1,0 +1,64 @@
+import { Minus, Plus } from "lucide-react";
+
+interface CartItemProps {
+  item: {
+    cartItemId: number;
+    productName: string;
+    price: number;
+    quantity: number;
+    imgURL: string;
+  };
+  isSelected: boolean;
+  onSelect: (cartItemId: number) => void;
+  onUpdateQuantity: (cartItemId: number, newQuantity: number) => void;
+}
+
+export function CartItem({
+  item,
+  isSelected,
+  onSelect,
+  onUpdateQuantity,
+}: CartItemProps) {
+  return (
+    <div className="flex items-start gap-4">
+      <input
+        type="checkbox"
+        checked={isSelected}
+        onChange={() => onSelect(item.cartItemId)}
+        className="mt-2 size-5 rounded border-gray-300 text-green-500 focus:ring-green-500"
+      />
+      <div className="flex flex-1 gap-4">
+        <img
+          src={item.imgURL}
+          alt={item.productName}
+          className="size-20 rounded-md object-cover"
+        />
+        <div className="flex-1">
+          <h3 className="text-sm font-medium">{item.productName}</h3>
+          <p className="mt-1 text-sm text-gray-900">
+            {item.price.toLocaleString()}원
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <button
+              onClick={() =>
+                onUpdateQuantity(item.cartItemId, item.quantity - 1)
+              }
+              className="rounded-md border p-2"
+            >
+              <Minus className="size-4" />
+            </button>
+            <span className="w-8 text-center">{item.quantity}</span>
+            <button
+              onClick={() =>
+                onUpdateQuantity(item.cartItemId, item.quantity + 1)
+              }
+              className="rounded-md border p-2"
+            >
+              <Plus className="size-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/feature/cart/DeleteConfiemModal.tsx
+++ b/feature/cart/DeleteConfiemModal.tsx
@@ -1,0 +1,37 @@
+import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
+
+interface DeleteConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+}: DeleteConfirmModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="p-0 sm:max-w-[320px]">
+        <div className="p-6">
+          <p className="text-center text-base">삭제하시겠습니까?</p>
+        </div>
+        <DialogFooter className="flex border-t p-0">
+          <button
+            onClick={onClose}
+            className="flex-1 border-r p-4 text-sm hover:bg-gray-50"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 p-4 text-sm text-green-600 hover:bg-gray-50"
+          >
+            확인
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/feature/cart/shopping-cart.tsx
+++ b/feature/cart/shopping-cart.tsx
@@ -1,49 +1,12 @@
 "use client";
 import { useState, useEffect, useContext } from "react";
 import axios from "axios";
-import { Minus, Plus } from "lucide-react";
-import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { AuthContext } from "@/context/AuthContext";
 import Link from "next/link";
-
-// 삭제 확인 모달 컴포넌트
-interface DeleteConfirmModalProps {
-  isOpen: boolean; // 모달 열림
-  onClose: () => void; // 모달 닫기
-  onConfirm: () => void; // 삭제 확인 함수
-}
-
-function DeleteConfirmModal({
-  isOpen,
-  onClose,
-  onConfirm,
-}: DeleteConfirmModalProps) {
-  return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="p-0 sm:max-w-[320px]">
-        <div className="p-6">
-          <p className="text-center text-base">삭제하시겠습니까?</p>
-        </div>
-        <DialogFooter className="flex border-t p-0">
-          <button
-            onClick={onClose}
-            className="flex-1 border-r p-4 text-sm hover:bg-gray-50"
-          >
-            취소
-          </button>
-          <button
-            onClick={onConfirm}
-            className="flex-1 p-4 text-sm text-green-600 hover:bg-gray-50"
-          >
-            확인
-          </button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
+import { DeleteConfirmModal } from "@/feature/cart/DeleteConfiemModal";
+import { CartItem } from "@/feature/cart/CartItem";
 
 // 장바구니 아이템 타입
 interface CartItem {
@@ -63,9 +26,12 @@ interface CartData {
   totalPrice: number;
 }
 
-// 장바구니 컴포넌트
 export const ShoppingCart = () => {
-  const { isLoading: authLoading, isLoggedIn } = useContext(AuthContext); // AuthContext에서 로그인 상태 가져오기
+  const {
+    isLoading: authLoading,
+    isLoggedIn,
+    setIsLoggedIn,
+  } = useContext(AuthContext);
 
   const [cartData, setCartData] = useState<CartData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -75,43 +41,31 @@ export const ShoppingCart = () => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [itemsToDelete, setItemsToDelete] = useState<number[]>([]);
 
-  // 배송비 3000원 고정
   const shippingFee = 3000;
 
-  // useEffect로 로그인 상태에 따라 장바구니 데이터 가져오기
   useEffect(() => {
     if (isLoggedIn) {
-      // isLoggedIn === true → fetchCartData()를 호출하여 장바구니 정보를 서버에서 불러옴.
       fetchCartData();
     } else {
-      setLoading(false); // isLoggedIn === false → 로그인이 안 된 경우이므로 별도로 API를 부르지 않고 setLoading(false)로 로딩 완료로 처리.
+      setLoading(false);
     }
   }, [isLoggedIn]);
 
-  const axiosInstance = axios.create({
-    baseURL: "http://localhost:8080",
+  const axiosInstance = axios.create({ baseURL: "http://localhost:8080" });
+  axiosInstance.interceptors.request.use((config) => {
+    const token = localStorage.getItem("accessToken");
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
   });
 
-  // 요청 인터셉터로 Authorization 헤더 설정
-  axiosInstance.interceptors.request.use(
-    (config) => {
-      const token = localStorage.getItem("accessToken"); // AuthContext에서도 가능
-      if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
-      }
-      return config;
-    },
-    (error) => Promise.reject(error)
-  );
-
-  // 장바구니 데이터 가져오기
   const fetchCartData = async () => {
     try {
       setLoading(true);
       const response = await axiosInstance.get<CartData>("/cart");
 
       if (!response.data.cartItems || response.data.cartItems.length === 0) {
-        // 장바구니가 비어있을 경우에도 오류로 처리하지 않고 상태를 초기화
         setCartData({
           cartId: response.data.cartId,
           cartItems: [],
@@ -128,14 +82,13 @@ export const ShoppingCart = () => {
     } catch (err: any) {
       console.error("Error fetching cart data:", err);
 
-      // [변경] 401/403 오류 처리를 분기
       if (err.response?.status === 401 || err.response?.status === 403) {
-        setError("로그인이 필요합니다.");
-        // 필요 시 로그인 페이지로 강제 이동
-        // router.push("/login");
+        // setError("로그인이 필요합니다.");
+        // setCartData(null);
+        setIsLoggedIn(false);
         setCartData(null);
+        setError(null);
       } else {
-        // 그 외 에러인 경우
         setError("장바구니 데이터를 불러오는 중 오류가 발생했습니다.");
         setCartData(null);
       }
@@ -144,45 +97,6 @@ export const ShoppingCart = () => {
     }
   };
 
-  if (authLoading || loading) return <div>Loading...</div>;
-
-  // 로그인 인증이 되지 않은 사용자의 경우
-  if (!isLoggedIn) {
-    return (
-      <div className="min-h-screen bg-gray-50">
-        <Header title="장바구니" />
-        <div className="flex flex-col h-[50vh] items-center justify-center text-center">
-          <p className="text-2xl font-bold text-gray-700 mb-4">
-            로그인 후 이용해주세요
-          </p>
-          <Link
-            href="/login"
-            className="bg-green-500 text-white px-6 py-2 rounded-md hover:bg-green-600 transition-colors"
-          >
-            로그인하기
-          </Link>
-        </div>
-        <Footer />
-      </div>
-    );
-  }
-
-  if (error) return <div>{error}</div>;
-
-  // 로그인 인증이 된 사용자이지만, 장바구니에 담긴 상품이 없는 경우
-  if (!cartData || !cartData.cartItems || cartData.cartItems.length === 0) {
-    return (
-      <div className="min-h-screen bg-gray-50">
-        <Header title="장바구니" />
-        <div className="flex h-[50vh] items-center justify-center text-2xl font-bold text-gray-500">
-          🛒 장바구니가 비어있습니다.
-        </div>
-        <Footer />
-      </div>
-    );
-  }
-
-  // 수량 업데이트
   const updateQuantity = (cartItemId: number, newQuantity: number) => {
     setCartData((prev) => {
       if (!prev) return prev;
@@ -205,7 +119,6 @@ export const ShoppingCart = () => {
     debounceSaveCart(cartItemId, newQuantity);
   };
 
-  // 수량 저장 디바운스
   let saveTimeout: NodeJS.Timeout;
   const debounceSaveCart = (cartItemId: number, quantity: number) => {
     if (saveTimeout) clearTimeout(saveTimeout);
@@ -214,7 +127,6 @@ export const ShoppingCart = () => {
     }, 1000);
   };
 
-  // 수량 저장 요청
   const saveCartItemToServer = async (cartItemId: number, quantity: number) => {
     try {
       setIsSaving(true);
@@ -237,7 +149,6 @@ export const ShoppingCart = () => {
     }
   };
 
-  // 결제 처리
   const handleCheckout = async () => {
     if (!cartData) return;
     const selectedItemsTotal = calculateSelectedItemsTotal();
@@ -245,7 +156,6 @@ export const ShoppingCart = () => {
     alert("결제 페이지로 이동합니다!");
   };
 
-  // 개별 항목 선택 토글
   const toggleItemSelection = (cartItemId: number) => {
     setSelectedItems((prev) =>
       prev.includes(cartItemId)
@@ -254,7 +164,6 @@ export const ShoppingCart = () => {
     );
   };
 
-  // 전체 선택 토글
   const toggleSelectAll = () => {
     if (!cartData) return;
 
@@ -265,31 +174,27 @@ export const ShoppingCart = () => {
     }
   };
 
-  // 삭제 모달
   const handleDeleteClick = (items: number[]) => {
     setItemsToDelete(items);
     setIsDeleteModalOpen(true);
   };
 
-  // 선택 항목 상제
   const deleteSelectedItems = async () => {
     try {
-      // 선택된 cartItemId를 기반으로 삭제 요청
       await Promise.all(
         itemsToDelete.map((cartItemId) =>
           axiosInstance.delete(`/cart/item/${cartItemId}`)
         )
       );
 
-      setIsDeleteModalOpen(false); // 모달 닫기
-      fetchCartData(); // 데이터 새로고침
+      setIsDeleteModalOpen(false);
+      fetchCartData();
     } catch (err: any) {
       setError("선택한 상품 삭제 중 오류가 발생했습니다.");
       console.error("Error deleting items:", err);
     }
   };
 
-  // 선택된 항목 총 금액 계산
   const calculateSelectedItemsTotal = () => {
     if (!cartData) return 0;
     return cartData.cartItems
@@ -303,16 +208,38 @@ export const ShoppingCart = () => {
       .reduce((total, item) => total + item.price * item.quantity, 0);
   };
 
-  if (loading) return <div>Loading...</div>;
+  if (authLoading || loading) return <div>Loading...</div>;
+
+  if (!isLoggedIn) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <Header title="장바구니" />
+        <div className="flex flex-col h-[50vh] items-center justify-center text-center">
+          <p className="text-2xl font-bold text-gray-700 mb-4">
+            로그인 후 이용해주세요
+          </p>
+          <Link
+            href="/login"
+            className="bg-green-500 text-white px-6 py-2 rounded-md hover:bg-green-600 transition-colors"
+          >
+            로그인하기
+          </Link>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
   if (error) return <div>{error}</div>;
+
   if (!cartData || !cartData.cartItems || cartData.cartItems.length === 0) {
     return (
       <div className="min-h-screen bg-gray-50">
-        {/* 공통 Header 사용 */}
         <Header title="장바구니" />
         <div className="flex h-[50vh] items-center justify-center text-2xl font-bold text-gray-500">
           🛒 장바구니가 비어있습니다.
         </div>
+        <Footer />
       </div>
     );
   }
@@ -326,7 +253,6 @@ export const ShoppingCart = () => {
       <div className="p-4">
         <div className="min-h-screen bg-gray-50 p-4">
           <div>
-            {/* 상품 정보 */}
             <div className="border-b pb-4">
               <div className="mb-4 flex items-center justify-between">
                 <div className="flex items-center gap-2">
@@ -351,50 +277,13 @@ export const ShoppingCart = () => {
 
               <div className="space-y-4">
                 {cartData.cartItems.map((item) => (
-                  <div key={item.cartItemId} className="flex items-start gap-4">
-                    <input
-                      type="checkbox"
-                      checked={selectedItems.includes(item.cartItemId)}
-                      onChange={() => toggleItemSelection(item.cartItemId)}
-                      className="mt-2 size-5 rounded border-gray-300 text-green-500 focus:ring-green-500"
-                    />
-                    <div className="flex flex-1 gap-4">
-                      <img
-                        src={item.imgURL}
-                        alt={item.productName}
-                        className="size-20 rounded-md object-cover"
-                      />
-                      <div className="flex-1">
-                        <h3 className="text-sm font-medium">
-                          {item.productName}
-                        </h3>
-                        <p className="mt-1 text-sm text-gray-900">
-                          {item.price.toLocaleString()}원
-                        </p>
-                        <div className="mt-2 flex items-center gap-2">
-                          <button
-                            onClick={() =>
-                              updateQuantity(item.cartItemId, item.quantity - 1)
-                            }
-                            className="rounded-md border p-2"
-                          >
-                            <Minus className="size-4" />
-                          </button>
-                          <span className="w-8 text-center">
-                            {item.quantity}
-                          </span>
-                          <button
-                            onClick={() =>
-                              updateQuantity(item.cartItemId, item.quantity + 1)
-                            }
-                            className="rounded-md border p-2"
-                          >
-                            <Plus className="size-4" />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+                  <CartItem
+                    key={item.cartItemId}
+                    item={item}
+                    isSelected={selectedItems.includes(item.cartItemId)}
+                    onSelect={toggleItemSelection}
+                    onUpdateQuantity={updateQuantity}
+                  />
                 ))}
               </div>
             </div>

--- a/feature/cart/shopping-cart.tsx
+++ b/feature/cart/shopping-cart.tsx
@@ -41,7 +41,7 @@ export const ShoppingCart = () => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [itemsToDelete, setItemsToDelete] = useState<number[]>([]);
 
-  const shippingFee = 3000;
+  const shippingFee = 3000; // 배송비 고정
 
   useEffect(() => {
     if (isLoggedIn) {
@@ -83,8 +83,6 @@ export const ShoppingCart = () => {
       console.error("Error fetching cart data:", err);
 
       if (err.response?.status === 401 || err.response?.status === 403) {
-        // setError("로그인이 필요합니다.");
-        // setCartData(null);
         setIsLoggedIn(false);
         setCartData(null);
         setError(null);
@@ -97,6 +95,7 @@ export const ShoppingCart = () => {
     }
   };
 
+  // 수량 업데이트
   const updateQuantity = (cartItemId: number, newQuantity: number) => {
     setCartData((prev) => {
       if (!prev) return prev;
@@ -119,6 +118,7 @@ export const ShoppingCart = () => {
     debounceSaveCart(cartItemId, newQuantity);
   };
 
+  // 수량 저장 디바운스
   let saveTimeout: NodeJS.Timeout;
   const debounceSaveCart = (cartItemId: number, quantity: number) => {
     if (saveTimeout) clearTimeout(saveTimeout);
@@ -127,6 +127,7 @@ export const ShoppingCart = () => {
     }, 1000);
   };
 
+  // 수량 저장 요청
   const saveCartItemToServer = async (cartItemId: number, quantity: number) => {
     try {
       setIsSaving(true);
@@ -149,6 +150,7 @@ export const ShoppingCart = () => {
     }
   };
 
+  // 결제 처리
   const handleCheckout = async () => {
     if (!cartData) return;
     const selectedItemsTotal = calculateSelectedItemsTotal();
@@ -156,6 +158,7 @@ export const ShoppingCart = () => {
     alert("결제 페이지로 이동합니다!");
   };
 
+  // 개별 항목 선택 토글
   const toggleItemSelection = (cartItemId: number) => {
     setSelectedItems((prev) =>
       prev.includes(cartItemId)
@@ -164,6 +167,7 @@ export const ShoppingCart = () => {
     );
   };
 
+  // 전체 선택 토글
   const toggleSelectAll = () => {
     if (!cartData) return;
 
@@ -174,27 +178,31 @@ export const ShoppingCart = () => {
     }
   };
 
+  // 삭제 모달
   const handleDeleteClick = (items: number[]) => {
     setItemsToDelete(items);
     setIsDeleteModalOpen(true);
   };
 
+  // 선택 항목 삭제
   const deleteSelectedItems = async () => {
     try {
+      // 선택된 cartItemId를 기반으로 삭제 요청
       await Promise.all(
         itemsToDelete.map((cartItemId) =>
           axiosInstance.delete(`/cart/item/${cartItemId}`)
         )
       );
 
-      setIsDeleteModalOpen(false);
-      fetchCartData();
+      setIsDeleteModalOpen(false); // 모달 닫기
+      fetchCartData(); // 데이터 새로고침
     } catch (err: any) {
       setError("선택한 상품 삭제 중 오류가 발생했습니다.");
       console.error("Error deleting items:", err);
     }
   };
 
+  // 선택된 항목 총 금액 계산
   const calculateSelectedItemsTotal = () => {
     if (!cartData) return 0;
     return cartData.cartItems
@@ -213,6 +221,7 @@ export const ShoppingCart = () => {
   if (!isLoggedIn) {
     return (
       <div className="min-h-screen bg-gray-50">
+        {/* 공통 Header 사용 */}
         <Header title="장바구니" />
         <div className="flex flex-col h-[50vh] items-center justify-center text-center">
           <p className="text-2xl font-bold text-gray-700 mb-4">
@@ -253,6 +262,7 @@ export const ShoppingCart = () => {
       <div className="p-4">
         <div className="min-h-screen bg-gray-50 p-4">
           <div>
+            {/* 상품 정보 */}
             <div className="border-b pb-4">
               <div className="mb-4 flex items-center justify-between">
                 <div className="flex items-center gap-2">

--- a/feature/cart/shopping-cart.tsx
+++ b/feature/cart/shopping-cart.tsx
@@ -1,12 +1,12 @@
 "use client";
-
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
 import axios from "axios";
 import { Minus, Plus } from "lucide-react";
 import { Dialog, DialogContent, DialogFooter } from "@/components/ui/dialog";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
-import { useAuth } from "@/hooks/useAuth";
+import { AuthContext } from "@/context/AuthContext";
+import Link from "next/link";
 
 // 삭제 확인 모달 컴포넌트
 interface DeleteConfirmModalProps {
@@ -65,21 +65,29 @@ interface CartData {
 
 // 장바구니 컴포넌트
 export const ShoppingCart = () => {
-  const [cartData, setCartData] = useState<CartData | null>(null); // 장바구니 데이터 상테
-  const [loading, setLoading] = useState(true); // 로딩 상태
-  const [error, setError] = useState<string | null>(null); // 오류 상태
-  const [isSaving, setIsSaving] = useState(false); // 저장 상태
-  const [selectedItems, setSelectedItems] = useState<number[]>([]); // 선택된 아이템
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false); // 삭제 모달
+  const { isLoading: authLoading, isLoggedIn } = useContext(AuthContext); // AuthContext에서 로그인 상태 가져오기
+
+  const [cartData, setCartData] = useState<CartData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [selectedItems, setSelectedItems] = useState<number[]>([]);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [itemsToDelete, setItemsToDelete] = useState<number[]>([]);
 
-  const shippingFee = 3000; // 배송비 고정
+  // 배송비 3000원 고정
+  const shippingFee = 3000;
 
+  // useEffect로 로그인 상태에 따라 장바구니 데이터 가져오기
   useEffect(() => {
-    fetchCartData();
-  }, []);
+    if (isLoggedIn) {
+      // isLoggedIn === true → fetchCartData()를 호출하여 장바구니 정보를 서버에서 불러옴.
+      fetchCartData();
+    } else {
+      setLoading(false); // isLoggedIn === false → 로그인이 안 된 경우이므로 별도로 API를 부르지 않고 setLoading(false)로 로딩 완료로 처리.
+    }
+  }, [isLoggedIn]);
 
-  // 인증 구현 미 완성으로 헤더 직접 넣음
   const axiosInstance = axios.create({
     baseURL: "http://localhost:8080",
   });
@@ -117,30 +125,59 @@ export const ShoppingCart = () => {
       }
 
       setError(null);
-    } catch (err) {
+    } catch (err: any) {
       console.error("Error fetching cart data:", err);
-      setCartData({
-        cartId: 0,
-        cartItems: [],
-        totalPrice: 0,
-      });
-      setError(null); // UI를 "장바구니가 비어있습니다"로 유지하기 위해 오류를 초기화
+
+      // [변경] 401/403 오류 처리를 분기
+      if (err.response?.status === 401 || err.response?.status === 403) {
+        setError("로그인이 필요합니다.");
+        // 필요 시 로그인 페이지로 강제 이동
+        // router.push("/login");
+        setCartData(null);
+      } else {
+        // 그 외 에러인 경우
+        setError("장바구니 데이터를 불러오는 중 오류가 발생했습니다.");
+        setCartData(null);
+      }
     } finally {
       setLoading(false);
     }
   };
 
-  // UI 렌더링 조건
-  if (loading) return <div>Loading...</div>;
+  if (authLoading || loading) return <div>Loading...</div>;
 
-  // Error 상태를 제거하고 비어있는 경우에만 아래와 같은 UI를 렌더링
-  if (!cartData || cartData.cartItems.length === 0) {
+  // 로그인 인증이 되지 않은 사용자의 경우
+  if (!isLoggedIn) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <Header title="장바구니" />
+        <div className="flex flex-col h-[50vh] items-center justify-center text-center">
+          <p className="text-2xl font-bold text-gray-700 mb-4">
+            로그인 후 이용해주세요
+          </p>
+          <Link
+            href="/login"
+            className="bg-green-500 text-white px-6 py-2 rounded-md hover:bg-green-600 transition-colors"
+          >
+            로그인하기
+          </Link>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (error) return <div>{error}</div>;
+
+  // 로그인 인증이 된 사용자이지만, 장바구니에 담긴 상품이 없는 경우
+  if (!cartData || !cartData.cartItems || cartData.cartItems.length === 0) {
     return (
       <div className="min-h-screen bg-gray-50">
         <Header title="장바구니" />
         <div className="flex h-[50vh] items-center justify-center text-2xl font-bold text-gray-500">
           🛒 장바구니가 비어있습니다.
         </div>
+        <Footer />
       </div>
     );
   }

--- a/feature/category/category-header.tsx
+++ b/feature/category/category-header.tsx
@@ -1,4 +1,6 @@
-import { ShoppingBag } from "lucide-react";
+import { ShoppingCart } from "lucide-react";
+import Link from "next/link";
+
 interface CategoryHeaderProps {
   className?: string;
 }
@@ -9,7 +11,9 @@ export function CategoryHeader({ className = "" }: CategoryHeaderProps) {
       <div className="flex items-center justify-between px-4 py-3">
         <h1 className="text-lg font-medium">카테고리</h1>
         <div className="p-1">
-          <ShoppingBag size={24} />
+          <Link href="/cart">
+            <ShoppingCart size={24} />
+          </Link>
         </div>
       </div>
     </header>

--- a/feature/landing/marketHeader.tsx
+++ b/feature/landing/marketHeader.tsx
@@ -19,7 +19,7 @@ export default function MarketHeader() {
         </span>
         <ShoppingCart
           className="absolute right-[calc(50%-35px-125px)] top-[18px]"
-          size={20}
+          size={24}
           color="white"
           onClick={handleCartClick}
         />

--- a/feature/landing/marketHeader.tsx
+++ b/feature/landing/marketHeader.tsx
@@ -1,28 +1,22 @@
 "use client";
 
 import { ShoppingCart } from "lucide-react";
-// import Link from "next/link";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export default function MarketHeader() {
-  const router = useRouter();
-
-  const handleCartClick = () => {
-    router.push("/cart");
-  };
-
   return (
     <header className="relative h-[51px] bg-[#0DBD88]">
       <div className="flex items-center">
         <span className="absolute left-[calc(50%-35px-125px)] top-[10px] h-[31px] w-[160px] text-[20px] font-bold text-white">
           KurlyKelly
         </span>
-        <ShoppingCart
-          className="absolute right-[calc(50%-35px-125px)] top-[18px]"
-          size={24}
-          color="white"
-          onClick={handleCartClick}
-        />
+        <Link href="/cart">
+          <ShoppingCart
+            className="absolute right-[calc(50%-35px-125px)] top-[18px]"
+            size={24}
+            color="white"
+          />
+        </Link>
       </div>
     </header>
   );

--- a/feature/mymarket/mymarket-header.tsx
+++ b/feature/mymarket/mymarket-header.tsx
@@ -1,14 +1,10 @@
 import { ShoppingCart } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-
 interface MyMarketHeaderProps {
   className?: string;
 }
 
 export function MyMarketHeader({ className = " " }: MyMarketHeaderProps) {
-  const router = useRouter();
-
   return (
     <div className={`bg-emerald-500 px-4 py-3 text-white ${className}`}>
       <div className="relative">

--- a/feature/mymarket/mymarket-header.tsx
+++ b/feature/mymarket/mymarket-header.tsx
@@ -1,16 +1,22 @@
-import { ShoppingBag } from "lucide-react";
+import { ShoppingCart } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 interface MyMarketHeaderProps {
   className?: string;
 }
 
 export function MyMarketHeader({ className = " " }: MyMarketHeaderProps) {
+  const router = useRouter();
+
   return (
     <div className={`bg-emerald-500 px-4 py-3 text-white ${className}`}>
       <div className="relative">
         <div className="text-center text-lg font-medium">마이마켓</div>
         <div className="absolute right-0 top-1/2 -translate-y-1/2">
-          <ShoppingBag className="size-6" />
+          <Link href="/cart">
+            <ShoppingCart className="size-6" />
+          </Link>
         </div>
       </div>
     </div>

--- a/feature/productDetail/ProductHeader.tsx
+++ b/feature/productDetail/ProductHeader.tsx
@@ -1,7 +1,6 @@
 "use client";
 import Link from "next/link";
 import { IoArrowBack } from "react-icons/io5"; // 뒤로 가기 아이콘
-import { useRouter } from "next/navigation";
 import { ShoppingCart } from "lucide-react";
 
 interface ProductHeader {
@@ -9,8 +8,6 @@ interface ProductHeader {
 }
 
 export default function ProductHeader({ productName }: ProductHeader) {
-  const router = useRouter();
-
   return (
     <header className="p-4 border-b">
       <div className="flex items-center justify-between">

--- a/feature/productDetail/ProductHeader.tsx
+++ b/feature/productDetail/ProductHeader.tsx
@@ -1,8 +1,8 @@
 "use client";
 import Link from "next/link";
 import { IoArrowBack } from "react-icons/io5"; // 뒤로 가기 아이콘
-import { IoCart } from "react-icons/io5"; // 장바구니 아이콘
 import { useRouter } from "next/navigation";
+import { ShoppingCart } from "lucide-react";
 
 interface ProductHeader {
   productName: string; // imageUrl은 문자열 타입
@@ -24,7 +24,7 @@ export default function ProductHeader({ productName }: ProductHeader) {
 
         <div className="flex items-center ml-4">
           <Link href="/cart">
-            <IoCart className="text-lg text-gray-500 hover:text-green-500" />
+            <ShoppingCart className="text-lg text-gray-500 hover:text-green-500" />
           </Link>
         </div>
       </div>

--- a/feature/productList/productList-header.tsx
+++ b/feature/productList/productList-header.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { ShoppingBag } from "lucide-react";
+import { ShoppingCart } from "lucide-react";
 import { ChevronLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 interface ProductListHeaderProps {
   className?: string;
@@ -23,7 +24,9 @@ export function ProductListHeader({ className = "" }: ProductListHeaderProps) {
         </button>
         <h1 className="text-lg font-medium">채소</h1>
         <button className="p-1">
-          <ShoppingBag size={24} />
+          <Link href="/cart">
+            <ShoppingCart size={24} />
+          </Link>
         </button>
       </div>
     </header>

--- a/feature/search/search-header.tsx
+++ b/feature/search/search-header.tsx
@@ -1,4 +1,6 @@
-import { ShoppingBag } from "lucide-react";
+import { ShoppingCart } from "lucide-react";
+import Link from "next/link";
+
 interface SearchHeaderProps {
   className?: string;
 }
@@ -6,10 +8,12 @@ interface SearchHeaderProps {
 export function SearchHeader({ className = "" }: SearchHeaderProps) {
   return (
     <header className={`bg-emerald-500 text-white ${className}`}>
-      <div className="flex items-center justify-between px-4 py-3">
-        <h1 className="text-lg font-medium">검색</h1>
-        <div className="p-1">
-          <ShoppingBag size={24} />
+      <div className="relative py-3">
+        <h1 className="text-center text-lg font-medium">검색</h1>
+        <div className="absolute right-4 top-1/2 -translate-y-1/2 p-1">
+          <Link href="/cart">
+            <ShoppingCart size={24} />
+          </Link>
         </div>
       </div>
     </header>


### PR DESCRIPTION
[장바구니 아이콘]
- 모든 페이지의 장바구니 아이콘 통일 
- 모든 페이지에서 장바구니 아이콘 클릭 시 장바구니 화면으로 이동
- 장바구니 아이콘 버튼 라우팅이 Link와 useRouter 두가지가 섞여있길래 Link로 통일

[컴포넌트 분리]
- shopping-cart 컴포넌트 분리

[인증되지 않은 사용자의 장바구니]
- 로그인 인증이 되지 않은 사용자가 장바구니 버튼 클릭 시 "로그인 후 이용해주세요" 메세지 + 로그인 이동 버튼 추가
- 로그인 후 토큰이 존재해 장바구니가 잘 보이지만, localstorage에서 토큰을 삭제하면 기존 코드에서는 "로그인 후 이용해주세요"가 아닌 "로그인이 필요합니다"로 에러처리 됨
- 이유: 토큰을 지워도 isLoggedIn이 true로 남아있어서 에러 메세지 UI가 나오는 것 
- AuthContext에서 토큰이 없으면 isLoggedIn = false로 세팅 (상현오빠 코드 일부 수정 - 오빠 코드를 바꾼건 아니고 추가했어!)