### PR TITLE
Feature/find

### DIFF
--- a/app/find-id/page.tsx
+++ b/app/find-id/page.tsx
@@ -2,11 +2,24 @@
 import { Header } from "@/components/layout/header";
 import { PageLayout } from "@/components/layout/pagelayout";
 import { FindIdForm } from "@/feature/find-id/find-id-form";
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
 
 export default function FindIdPage() {
   return (
     <PageLayout>
-      <Header title="아이디 찾기" showDivider={false} />
+      <Header
+        title="아이디 찾기"
+        showDivider={false}
+        closeButton={
+          <Link
+            href="/login"
+            className="absolute left-4 top-1/2 -translate-y-1/2"
+          >
+            <ChevronLeft className="size-6" />
+          </Link>
+        }
+      />
       <FindIdForm />
     </PageLayout>
   );

--- a/app/find-id/page.tsx
+++ b/app/find-id/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { Header } from "@/components/layout/header";
+import { PageLayout } from "@/components/layout/pagelayout";
+import { FindIdForm } from "@/feature/find-id/find-id-form";
+
+export default function FindIdPage() {
+  return (
+    <PageLayout>
+      <Header title="아이디 찾기" showDivider={false} />
+      <FindIdForm />
+    </PageLayout>
+  );
+}

--- a/app/find-id/success/page.tsx
+++ b/app/find-id/success/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Header } from "@/components/layout/header";
+import { PageLayout } from "@/components/layout/pagelayout";
+import { FindIdSuccess } from "@/feature/find-id/find-id-success";
+import { useSearchParams } from "next/navigation";
+
+export default function FindIdSuccessPage() {
+  // 쿼리 파라미터 추출
+  const searchParams = useSearchParams();
+  const username = searchParams.get("username") || "unknown";
+
+  return (
+    <PageLayout>
+      <Header title="아이디 찾기" showDivider={false} />
+      <FindIdSuccess username={username} />
+    </PageLayout>
+  );
+}

--- a/app/find-id/success/page.tsx
+++ b/app/find-id/success/page.tsx
@@ -3,6 +3,8 @@
 import { Header } from "@/components/layout/header";
 import { PageLayout } from "@/components/layout/pagelayout";
 import { FindIdSuccess } from "@/feature/find-id/find-id-success";
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 
 export default function FindIdSuccessPage() {
@@ -12,7 +14,18 @@ export default function FindIdSuccessPage() {
 
   return (
     <PageLayout>
-      <Header title="아이디 찾기" showDivider={false} />
+      <Header
+        title="아이디 찾기"
+        showDivider={false}
+        closeButton={
+          <Link
+            href="/login"
+            className="absolute left-4 top-1/2 -translate-y-1/2"
+          >
+            <ChevronLeft className="h-6 w-6" />
+          </Link>
+        }
+      />
       <FindIdSuccess username={username} />
     </PageLayout>
   );

--- a/app/find-password/page.tsx
+++ b/app/find-password/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { Header } from "@/components/layout/header";
+import { PageLayout } from "@/components/layout/pagelayout";
+import { FindIdForm } from "@/feature/find-id/find-id-form";
+
+export default function FindIdPage() {
+  return (
+    <PageLayout>
+      <Header title="비밀번호 찾기" showDivider={false} />
+      <FindIdForm />
+    </PageLayout>
+  );
+}

--- a/components/modal/modal.tsx
+++ b/components/modal/modal.tsx
@@ -16,7 +16,7 @@ export function Modal({ isOpen, onClose, message }) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       {/* 모달 콘텐츠 영역 */}
-      <DialogContent className="w-[320px] h-[150px] p-0 rounded-xl">
+      <DialogContent className="w-[320px] h-[160px] p-0 rounded-xl">
         <div className="p-6">
           {/* 메시지 표시 영역 */}
           <p className="text-center mb-4">{message}</p>

--- a/components/modal/modal.tsx
+++ b/components/modal/modal.tsx
@@ -16,7 +16,7 @@ export function Modal({ isOpen, onClose, message }) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       {/* 모달 콘텐츠 영역 */}
-      <DialogContent className="sm:max-w-[300px] p-0 rounded-xl">
+      <DialogContent className="w-[320px] h-[150px] p-0 rounded-xl">
         <div className="p-6">
           {/* 메시지 표시 영역 */}
           <p className="text-center mb-4">{message}</p>

--- a/feature/find-id/api/find-id-api.ts
+++ b/feature/find-id/api/find-id-api.ts
@@ -1,0 +1,34 @@
+import myApi from "@/lib/axios";
+
+const BASE_PATH = "/users/find-id";
+
+/**
+ * [아이디 찾기] API 모듈
+ */
+
+export const findIdApi = {
+  /**
+   * 이메일 인증번호 발송
+   * @Param name 사용자 이름
+   * @Param email 사용자 이메일
+   * @returns Promise (성공 시 메세지를 문자열로 반환)
+   */
+  sendEmailCode: (name: string, email: string) => {
+    // 예) POST /users/find-id/send-code?name=xxx&email=xxx
+    return myApi.post(`${BASE_PATH}/send-code?name=${name}&email=${email}`);
+  },
+
+  /**
+   * 이메일 인증번호 검증
+   * @Param name 사용자 이름
+   * @Param email 사용자 이메일
+   * @Param code 인증번호
+   * returns Promise (성공 시 아이디를 문자열로 반환)
+   */
+  verifyEmailCode: (name: string, email: string, code: string) => {
+    return myApi.post(
+      // 예) POST /users/find-id/verify-code?name=xxx&email=xxx&code=xxx
+      `${BASE_PATH}/verify-code?name=${name}&email=${email}&code=${code}`
+    );
+  },
+};

--- a/feature/find-id/find-id-form.tsx
+++ b/feature/find-id/find-id-form.tsx
@@ -47,9 +47,9 @@ export function FindIdForm() {
     try {
       if (verificationType === "email") {
         // 이메일 인증번호 발송 API 호출
-        const res = await findIdApi.sendEmailCode(name, contact);
-        // 예 : response.data = "인증번호가 발송되었습니다."
-        console.log(res.data);
+        const r = await findIdApi.sendEmailCode(name, contact);
+        // 예 : r.data = "인증번호가 발송되었습니다."
+        console.log(r.data);
       } else {
         // 휴대폰 인증 (미구현)
       }
@@ -63,7 +63,12 @@ export function FindIdForm() {
       setShowModal(true);
     } catch (error: any) {
       console.error(error);
-      const errMsg = error.res?.data || "인증번호 발송 중 오류가 발생했습니다";
+      // 기본 오류 메세지
+      let errMsg = "인증번호 발송 중 오류가 발생했습니다";
+      // 서버에서 보내준 메세지
+      if (error.rponse?.data) {
+        errMsg = error.rponse.data;
+      }
       setModalMessage(errMsg);
       setShowModal(true);
     }

--- a/feature/find-id/find-id-form.tsx
+++ b/feature/find-id/find-id-form.tsx
@@ -47,14 +47,14 @@ export function FindIdForm() {
     try {
       if (verificationType === "email") {
         // 이메일 인증번호 발송 API 호출
-        const r = await findIdApi.sendEmailCode(name, contact);
+        const response = await findIdApi.sendEmailCode(name, contact);
         // 예 : r.data = "인증번호가 발송되었습니다."
-        console.log(r.data);
+        console.log(response.data);
       } else {
         // 휴대폰 인증 (미구현)
       }
 
-      // 인증번호 입력창 표시, 타이버 3분 시작
+      // 인증번호 입력창 표시, 타이머 3분 시작
       setShowVerificationInput(true);
       setTimer(180);
 
@@ -66,8 +66,8 @@ export function FindIdForm() {
       // 기본 오류 메세지
       let errMsg = "인증번호 발송 중 오류가 발생했습니다";
       // 서버에서 보내준 메세지
-      if (error.rponse?.data) {
-        errMsg = error.rponse.data;
+      if (error.response?.data) {
+        errMsg = error.response.data;
       }
       setModalMessage(errMsg);
       setShowModal(true);

--- a/feature/find-id/find-id-form.tsx
+++ b/feature/find-id/find-id-form.tsx
@@ -1,0 +1,143 @@
+import { Modal } from "@/components/modal/modal";
+import { SecondModal } from "@/components/modal/secondmodal";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useState } from "react";
+
+type VerificationType = "phone" | "email";
+
+export function FindIdForm() {
+  const [verificationType, setVerificationType] =
+    useState<VerificationType>("phone");
+  const [name, setName] = useState("");
+  const [contact, setContact] = useState("");
+  const [verificationCode, setVerificationCode] = useState("");
+  const [showVerificationInput, setShowVerificationInput] = useState(false);
+  const [timer, setTimer] = useState<number | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+
+  const handleVerificationRequest = () => {
+    if (!name || !contact) {
+      setModalMessage("모든 정보를 입력해주세요");
+      setShowModal(true);
+      return;
+    }
+    setShowVerificationInput(true);
+    setTimer(180);
+    setModalMessage("인증번호가 발송되었습니다.");
+    setShowModal(true);
+  };
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${String(mins).padStart(2, "0")}: ${String(secs).padStart(2, "0")}`;
+  };
+
+  return (
+    <div className="px-4 pb-4">
+      <div className="flex border-b border-gray-200 mb-6">
+        <button
+          className={`flex-1 py-3 text-base ${
+            verificationType === "phone"
+              ? "text-emerald-500 border-b-2 border-emerald-500"
+              : "text-gray-400"
+          }`}
+          onClick={() => setVerificationType("phone")}
+        >
+          휴대폰 인증
+        </button>
+        <button
+          className={`flex-1 py-3 text-base ${
+            verificationType === "email"
+              ? "text-emerald-500 border-b-2 border-emerald-500"
+              : "text-gray-400"
+          }`}
+          onClick={() => setVerificationType("email")}
+        >
+          이메일 인증
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <Label htmlFor="name">이름</Label>
+          <Input
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={`이름을 입력해주세요`}
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="contact">
+            {verificationType === "phone" ? "휴대폰 번호" : "이메일"}
+          </Label>
+          <Input
+            id="contact"
+            type={verificationType === "phone" ? "tel" : "email"}
+            value={contact}
+            onChange={(e) => setContact(e.target.value)}
+            placeholder={
+              verificationType === "phone"
+                ? "휴대폰 번호를 입력해주세요"
+                : "이메일을 입력해주세요"
+            }
+          />
+        </div>
+
+        {showVerificationInput && (
+          <div>
+            <Label htmlFor="verificationCode">인증번호</Label>
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <Input
+                  id="verificationCode"
+                  value={verificationCode}
+                  onChange={(e) => setVerificationCode(e.target.value)}
+                  placeholder="인증번호 입력"
+                />
+                {timer !== null && (
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-red-500">
+                    {formatTime(timer)}
+                  </span>
+                )}
+              </div>
+              <Button
+                variant="outline"
+                className="border-emerald-500 text-emerald-500 hover:bg-emerald-50"
+              >
+                인증번호 확인
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <Button
+          className="w-full bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          onClick={handleVerificationRequest}
+          disabled={showVerificationInput || !name || !contact}
+        >
+          {verificationType === "phone" ? "인증번호 받기" : "확인"}
+        </Button>
+      </div>
+
+      {/* <SecondModal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        title="알림"
+        description={modalMessage}
+        confirmText="확인"
+        onConfirm={() => setShowModal(false)}
+      /> */}
+      <Modal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        message="인증번호가 발송되었습니다."
+      />
+    </div>
+  );
+}

--- a/feature/find-id/find-id-form.tsx
+++ b/feature/find-id/find-id-form.tsx
@@ -36,6 +36,9 @@ export function FindIdForm() {
   const [showModal, setShowModal] = useState(false);
   const [modalMessage, setModalMessage] = useState("");
 
+  // "인증번호 받기" 버튼이 로딩 중인지 여부
+  const [isLoadingSend, setIsLoadingSend] = useState(false);
+
   // 1) 인증번호 발송 버튼 핸들러
   const handleVerificationRequest = async () => {
     if (!name || !contact) {
@@ -43,6 +46,12 @@ export function FindIdForm() {
       setShowModal(true);
       return;
     }
+
+    // 이미 로딩 중이면(버튼 클릭 직후) 재요청 방지
+    if (isLoadingSend) return;
+
+    // 로딩 시작
+    setIsLoadingSend(true);
 
     try {
       if (verificationType === "email") {
@@ -71,6 +80,8 @@ export function FindIdForm() {
       }
       setModalMessage(errMsg);
       setShowModal(true);
+    } finally {
+      setIsLoadingSend(false);
     }
   };
 
@@ -232,9 +243,10 @@ export function FindIdForm() {
           <Button
             className="w-full bg-emerald-500 hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
             onClick={handleVerificationRequest}
-            disabled={showVerificationInput || !name || !contact}
+            // 로딩 중이거나 입력이 비었으면 비활성화
+            disabled={isLoadingSend || !name || !contact}
           >
-            인증번호 받기
+            {isLoadingSend ? "요청 중..." : "인증번호 받기"}
           </Button>
         )}
       </div>

--- a/feature/find-id/find-id-success.tsx
+++ b/feature/find-id/find-id-success.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { UserCircle2 } from "lucide-react";
+import Link from "next/link";
+
+interface FindIdSuccessProps {
+  username?: string;
+}
+
+export function FindIdSuccess({ username = "examId" }: FindIdSuccessProps) {
+  return (
+    <div className="px-4 py-6">
+      <div className="mb-12 space-y-2 text-center">
+        <h2 className="text-lg font-medium">고객님의 계정을 찾았습니다.</h2>
+        <p className="text-gray-600 text-sm">아이디 확인 후 로그인 해주세요.</p>
+      </div>
+
+      <div className="flex flex-col items-center mb-12">
+        <UserCircle2 className="w-16 h-16 text-gray-300 mb-4" />
+        <span className="text-lg">{username}</span>
+      </div>
+
+      <div className="space-y-2">
+        <Link href="/find-password" className="block">
+          <Button
+            variant="outline"
+            className="w-full border-emerald-500 text-emerald-500 hover:bg-emerald-50"
+          >
+            비밀번호 찾기
+          </Button>
+        </Link>
+        <Link href="/login" className="block">
+          <Button className="w-full bg-emerald-500 hover:bg-emerald-600">
+            로그인
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/feature/find-password/find-password-form.tsx
+++ b/feature/find-password/find-password-form.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Modal } from "@/components/modal/modal";
+
+type VerificationType = "phone" | "email";
+
+export function FindPasswordForm() {
+  const [verificationType, setVerificationType] =
+    useState<VerificationType>("phone");
+  const [id, setId] = useState("");
+  const [contact, setContact] = useState("");
+  const [verificationCode, setVerificationCode] = useState("");
+  const [showVerificationInput, setShowVerificationInput] = useState(false);
+  const [timer, setTimer] = useState<number | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+
+  const handleVerificationRequest = () => {
+    if (!id || !contact) {
+      setModalMessage("모든 정보를 입력해주세요");
+      setShowModal(true);
+      return;
+    }
+    setShowVerificationInput(true);
+    setTimer(180); // 3 minutes in seconds
+    setModalMessage("인증번호가 발송되었습니다.");
+    setShowModal(true);
+  };
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+  };
+
+  return (
+    <div className="px-4 pb-4">
+      <div className="flex border-b border-gray-200 mb-6">
+        <button
+          className={`flex-1 py-3 text-base ${
+            verificationType === "phone"
+              ? "text-emerald-500 border-b-2 border-emerald-500"
+              : "text-gray-400"
+          }`}
+          onClick={() => setVerificationType("phone")}
+        >
+          휴대폰 인증
+        </button>
+        <button
+          className={`flex-1 py-3 text-base ${
+            verificationType === "email"
+              ? "text-emerald-500 border-b-2 border-emerald-500"
+              : "text-gray-400"
+          }`}
+          onClick={() => setVerificationType("email")}
+        >
+          이메일 인증
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <Label htmlFor="id">아이디</Label>
+          <Input
+            id="id"
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            placeholder="아이디를 입력해주세요"
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="contact">
+            {verificationType === "phone" ? "휴대폰 번호" : "이메일"}
+          </Label>
+          <Input
+            id="contact"
+            type={verificationType === "phone" ? "tel" : "email"}
+            value={contact}
+            onChange={(e) => setContact(e.target.value)}
+            placeholder={
+              verificationType === "phone"
+                ? "휴대폰 번호를 입력해주세요"
+                : "이메일을 입력해주세요"
+            }
+          />
+        </div>
+
+        {showVerificationInput && (
+          <div>
+            <Label htmlFor="verificationCode">인증번호</Label>
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <Input
+                  id="verificationCode"
+                  value={verificationCode}
+                  onChange={(e) => setVerificationCode(e.target.value)}
+                  placeholder="인증번호 입력"
+                />
+                {timer !== null && (
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-red-500">
+                    {formatTime(timer)}
+                  </span>
+                )}
+              </div>
+              <Button
+                variant="outline"
+                className="border-emerald-500 text-emerald-500 hover:bg-emerald-50"
+              >
+                인증번호 확인
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <Button
+          className="w-full bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          onClick={handleVerificationRequest}
+          disabled={showVerificationInput || !id || !contact}
+        >
+          {verificationType === "phone" ? "인증번호 받기" : "확인"}
+        </Button>
+      </div>
+
+      <Modal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        message="인증번호가 발송되었습니다."
+      />
+    </div>
+  );
+}

--- a/feature/login/login-form.tsx
+++ b/feature/login/login-form.tsx
@@ -86,9 +86,13 @@ export default function LoginForm() {
 
         {/* 아이디/비밀번호 찾기 */}
         <div className="flex justify-center space-x-4 text-sm text-gray-600">
-          <button className="hover:underline">아이디찾기</button>
+          <Link href="/find-id" className="hover:underline">
+            아이디찾기
+          </Link>
           <div className="text-gray-300">|</div>
-          <button className="hover:underline">비밀번호찾기</button>
+          <Link href="/find-password" className="hover:underline">
+            비밀번호찾기
+          </Link>
         </div>
 
         {/* 카카오 로그인 */}


### PR DESCRIPTION
**UI 구현**
 - 아이디 찾기 및 비밀번호 찾기 페이지 UI구현

**아이디 찾기 API 호출**
 - 백엔드와 연동, 이름과 이메일을 입력하면 인증번호를 발송하고 검증하는 API 호출 구현
 - 사용자 입력 검증 및 서버 응답처리, 성공과 오류에 따라 다른 UI 반응 구현

**성공 페이지 라우팅**
 - 인증 성공 시 /find-id/success로 페이지로 라우팅, URL의 쿼리 파라미터를 통해 반환받은 아이디(username) 표시

**헤더 수정**
 - 아이디 찾기 헤더에서 'X' 버튼을 '<' 버튼으로 변경, 대상 페이지를 landing page가 아닌 login page로 라우팅

**오류 메세지 처리**
 - 모달 안내 메세지를 서버에서 보내준 오류 메세지로 수정
 - 서버 응답을 기반으로 오류처리 

**로딩 상태 추가**
 - "인증번호 받기" 버튼에 로딩 상태 추가, API 요청 중 버튼을 비활성화 하고 "요청 중..." 텍스트로 대체 표시
 - 버튼의 중복 클릭으로 인한 중복 요청 방지